### PR TITLE
change const to let to fix esbuild warning/error

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ if (typeof window !== 'undefined') {
   const handlePop = () => {
     
     const params = new URLSearchParams(window.location.search)
-    for (const [param, value] of params) {
+    for (let [param, value] of params) {
       try {
         value = JSON.parse(value)
       }


### PR DESCRIPTION
When I tried to use this library in a project and build with snowpack, it gave me an error. Here is a reproducible example:
```
$ npx esbuild index.js 
 > index.js:25:8: warning: This assignment will throw because "value" is a constant
    25 │         value = JSON.parse(value)
       ╵         ~~~~~
   index.js:23:23: note: "value" was declared a constant here
    23 │     for (const [param, value] of params) {
       ╵                        ~~~~~
```
(it seems that esbuild/snowpack considers this a warning in dev, but an error when bundling to deploy)

So I just changed that `const` to a `let` and now it works fine.



Also, I just wanted to say, thank you for making this library! I think it's really cool!
